### PR TITLE
Fix ArgumentException when using Azure Media Storage

### DIFF
--- a/Services/FaviconService.cs
+++ b/Services/FaviconService.cs
@@ -48,7 +48,7 @@ namespace Vandelay.Industries.Services {
         public IEnumerable<string> GetFaviconSuggestions() {
             List<string> faviconSuggestions = null;
             var rootMediaFolders = _mediaService
-                .GetMediaFolders(".")
+                .GetMediaFolders(String.Empty)
                 .Where(f => f.Name.Equals(FaviconMediaFolder, StringComparison.OrdinalIgnoreCase));
             if (rootMediaFolders.Any()) {
                 faviconSuggestions = new List<string>(


### PR DESCRIPTION
AzureFileSystem is trying to create a folder called "." whcih ends up throwing an exception.

The net result is that the settings page was not rendered. There is just an empty screen with a save button.